### PR TITLE
Add .envrc and fix devShell to work with more tools

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /target
 /result*
+/.direnv

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,10 @@
 
         devShell = pkgs.mkShell {
           inputsFrom = builtins.attrValues self.packages.${system};
+          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
           buildInputs = with pkgs; [
+            rustc
+            rust.packages.stable.rustPlatform.rustLibSrc
             nix'
             cargo
             rust-analyzer


### PR DESCRIPTION
I decided to ditch my impure ad-hoc usage of `rustup` where it's not needed and use the devShell while working on this project, so this fixes the devShell to work with my neovim plugin (and others) and adds a `.envrc` to save me running `nix shell`