### PR TITLE
Fix rebase

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 use flake

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
         };
 
         devShell = pkgs.mkShell {
+          RUST_LOG = "trace";
           inputsFrom = builtins.attrValues self.packages.${system};
           RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
           buildInputs = with pkgs; [

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::types::*;
-use thiserror::Error;
 use log::warn;
+use thiserror::Error;
 
 mod github;
 
@@ -23,10 +23,10 @@ pub async fn submit_or_update_request(
     match handle {
         RepoHandle::GitHub { owner, repo } => {
             github::submit_or_update_pull_request(settings, owner, repo, diff, submit).await?;
-        },
+        }
         RepoHandle::GitNone { url } => {
             warn!("Not sending a pull request for {}", url);
-        },
+        }
     }
     Ok(())
 }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -4,6 +4,7 @@
 
 use super::types::*;
 use thiserror::Error;
+use log::warn;
 
 mod github;
 
@@ -22,7 +23,10 @@ pub async fn submit_or_update_request(
     match handle {
         RepoHandle::GitHub { owner, repo } => {
             github::submit_or_update_pull_request(settings, owner, repo, diff, submit).await?;
-        }
+        },
+        RepoHandle::GitNone { url } => {
+            warn!("Not sending a pull request for {}", url);
+        },
     }
     Ok(())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,9 +69,16 @@ pub struct UpdateState {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
+/// Supported repository types.
+/// All repositories are fetched and pushed using git, but pull requests are submitted differently.
 pub enum RepoHandle {
     #[serde(rename = "github")]
+    /// GitHub: fetches with ssh, submits pull requests using GitHub API.
     GitHub { owner: String, repo: String },
+    #[serde(rename = "git+none")]
+    /// Pure git with **no pull request support**.
+    /// Useful for debugging.
+    GitNone { url: String },
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -86,7 +93,10 @@ impl Display for RepoHandle {
         match self {
             RepoHandle::GitHub { owner, repo, .. } => {
                 write!(f, "ssh://git@github.com/{}/{}", owner, repo)?;
-            }
+            },
+            RepoHandle::GitNone { url, .. } => {
+                write!(f, "{}", url)?;
+            },
         };
         Ok(())
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -93,10 +93,10 @@ impl Display for RepoHandle {
         match self {
             RepoHandle::GitHub { owner, repo, .. } => {
                 write!(f, "ssh://git@github.com/{}/{}", owner, repo)?;
-            },
+            }
             RepoHandle::GitNone { url, .. } => {
                 write!(f, "{}", url)?;
-            },
+            }
         };
         Ok(())
     }


### PR DESCRIPTION
- Add a git+none repo type for debugging

A new repo type which supports any git URL, but doesn't submit any pull
requests. Useful for debugging with local repos, and probably self-hosted
too.

- Fix rebasing

Rebasing was broken. Fix it. See commit message.
