### PR TITLE
Bump dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "crate2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1626172493,
-        "narHash": "sha256-NB/8p5swUe1zNcV2X5PBxR3WUg8OhT/l/5unXAn81As=",
+        "lastModified": 1631529284,
+        "narHash": "sha256-vUgjeI+B0lN/tExyGW5Rm7ux4JZgNd8883Oe2kV+czA=",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "0850394d3ed5927d2b9fda91eaa955d013397077",
+        "rev": "f20634d37133a5ec43d098238b026eca9a21e500",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1606424373,
-        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1626211675,
-        "narHash": "sha256-4a1rH5N7IQF61QG7SoS8bYKec9X1z7IcF0f3Tcc0eHw=",
-        "owner": "NixOS",
+        "lastModified": 1628513531,
+        "narHash": "sha256-DHuSZI+0XvMTmHPNnebs+zqgsdDkrnQckLXPLCIFroE=",
+        "owner": "nixos",
         "repo": "nix",
-        "rev": "bee71d692a10c9fcdc78f589945b9710f676cefb",
+        "rev": "27444d40cf726129334899a42d68d69f73baa988",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1622223326,
-        "narHash": "sha256-kVb9eGqc+JLENFcctmPyQml1y0xZqvBnykT5niwy/js=",
+        "lastModified": 1631273642,
+        "narHash": "sha256-LeD8U6LijyPHgr5ECLk7cobb4EkgPyPJJjxcYNi8noo=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "cf67659f17ba891def51bd718b2722a4065fcda3",
+        "rev": "1714a2ead1a18678afa3cbf75dff3f024c579061",
         "type": "github"
       },
       "original": {
@@ -239,11 +239,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1628069757,
-        "narHash": "sha256-x1+O+yW87hQCKRp7lPMMzO8Y1VHAI6Mm3CUycmuKw8M=",
+        "lastModified": 1629443741,
+        "narHash": "sha256-7bZGo9qXYxYD2FMZWlWoQbp3/NNG1YSHLEjEOHI4YRM=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "888b8a9c4e06b4753ffd7ec670e5f36430185fe6",
+        "rev": "46d762e5107d10ad409295a7f668939c21cc048d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update nix dependencies, to keep them up to date.

Related issue: https://issues.serokell.io/issue/OPS-1269