### PR TITLE
[#13] Add delay between pull request updates

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -91,6 +91,11 @@ in {
           description = "Extra lines to add to pull request body";
           default = "";
         };
+        cooldown = mkOption {
+          type = int;
+          description = "Cooldown duration between updating pull requests (in milliseconds)";
+          default = 100;
+        };
       };
     };
   config = lib.mkIf cfg.enable {

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use std::default::Default;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -16,6 +17,7 @@ pub struct UpdateSettings {
     pub default_branch: String,
     pub title: String,
     pub extra_body: String,
+    pub cooldown: Duration,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -31,6 +33,7 @@ pub struct UpdateSettingsOptional {
     pub default_branch: Option<String>,
     pub title: Option<String>,
     pub extra_body: Option<String>,
+    pub cooldown: Option<u64>,
 }
 
 #[derive(Debug, Error)]
@@ -58,6 +61,8 @@ impl std::convert::TryInto<UpdateSettings> for UpdateSettingsOptional {
                 .title
                 .unwrap_or("Automatically update flake.lock".to_string()),
             extra_body: self.extra_body.unwrap_or(String::new()),
+            // what if negative number in config?
+            cooldown: Duration::from_millis(unoption(self.cooldown, "cooldown")?),
         })
     }
 }


### PR DESCRIPTION
# Description

Add configurable cooldown duration between each
pull request update.

I decided to insert delay between each `submit_or_update_pull_request` and `submit_error_report` invocations, so this change also affects GitLab.

# Fixes #13 