### PR TITLE
[OPS-811] fix devshell compiling source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
             rust-analyzer
             rustfmt
             clippy
-            openssl
+            openssl_1_1
             pkg-config
             reuse
           ];


### PR DESCRIPTION
Problem: the `cargo` command in the devshell was unable to compile the source code due to an openssl version mismatch

Solution: adjust the devshell's openssl version accordingly