### PR TITLE
[OPS-1441] Add the ability to specify a list of inputs to update

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -96,6 +96,17 @@ in {
           description = "Cooldown duration between updating pull requests (in milliseconds)";
           default = 100;
         };
+        inputs = mkOption {
+          type = listOf str;
+          description = "List of input names to be updated, if empty, all inputs will be updated";
+          default = [];
+          example = [ "haskell-nix" ];
+        };
+        allow_missing_inputs = mkOption {
+          type = bool;
+          description = "If set to true, the update-daemon will not abort flake update if one of the names specified in the inputs option is not present in the flake.lock root node";
+          default = false;
+        };
       };
     };
   config = lib.mkIf cfg.enable {

--- a/src/flake_lock/mod.rs
+++ b/src/flake_lock/mod.rs
@@ -115,7 +115,7 @@ impl Lock {
         self.nodes.get(&self.resolve_input(dep)?)?.locked.clone()
     }
 
-    fn get_root_dep(&self, name: String) -> Option<Locked> {
+    pub fn get_root_dep(&self, name: String) -> Option<Locked> {
         self.get_dep(self.root_deps()?.get(&name)?.clone())
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,8 @@ pub struct UpdateSettings {
     pub title: String,
     pub extra_body: String,
     pub cooldown: Duration,
+    pub inputs: Vec<String>,
+    pub allow_missing_inputs: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -34,6 +36,8 @@ pub struct UpdateSettingsOptional {
     pub title: Option<String>,
     pub extra_body: Option<String>,
     pub cooldown: Option<u64>,
+    pub inputs: Option<Vec<String>>,
+    pub allow_missing_inputs: Option<bool>,
 }
 
 #[derive(Debug, Error)]
@@ -63,6 +67,8 @@ impl std::convert::TryInto<UpdateSettings> for UpdateSettingsOptional {
             extra_body: self.extra_body.unwrap_or_default(),
             // what if negative number in config?
             cooldown: Duration::from_millis(unoption(self.cooldown, "cooldown")?),
+            inputs: self.inputs.unwrap_or_else(|| vec![]),
+            allow_missing_inputs: self.allow_missing_inputs.unwrap_or_else(|| false),
         })
     }
 }


### PR DESCRIPTION
Problem: Currently `update-daemon` updates all non-pinned flake inputs, but this is not always desirable. We need to add support for updating only specific inputs specified in the config.

Solution: Add `inputs` and `allow_missing_inputs` config options, use `nix flake lock` to update the inputs specified in the `inputs` config option.