### PR TITLE
[#25] Avoid unnecessary force pushes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,7 @@
     "deploy-rs": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "utils": "utils"
       },
       "locked": {
@@ -17,25 +17,6 @@
       "original": {
         "id": "deploy-rs",
         "type": "indirect"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1673331886,
-        "narHash": "sha256-7P7xjE67AN6Jiz4wDTSnRPkb05hKvpJUp7I4j7t4ESw=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "d6ec6262ff2f256cad57470fc54410f2c0e91329",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
       }
     },
     "flake-compat": {
@@ -162,7 +143,7 @@
     },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1671096816,
@@ -181,7 +162,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -200,7 +181,7 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1633098935,
@@ -219,16 +200,13 @@
       "locked": {
         "lastModified": 1673226411,
         "narHash": "sha256-b6cGb5Ln7Zy80YO66+cbTyGdjZKtkoqB/iIIhDX9gRA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
+        "path": "/nix/store/9yaq152139igbs6rlma7mnl4hly1l07y-source",
         "rev": "aa1d74709f5dac623adb4d48fdfb27cc2c92a4d4",
-        "type": "github"
+        "type": "path"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "nixpkgs-regression": {
@@ -249,19 +227,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1673226411,
-        "narHash": "sha256-b6cGb5Ln7Zy80YO66+cbTyGdjZKtkoqB/iIIhDX9gRA=",
-        "path": "/nix/store/9yaq152139igbs6rlma7mnl4hly1l07y-source",
-        "rev": "aa1d74709f5dac623adb4d48fdfb27cc2c92a4d4",
-        "type": "path"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1645296114,
         "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
         "owner": "NixOS",
@@ -276,7 +241,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1672791794,
         "narHash": "sha256-mqGPpGmwap0Wfsf3o2b6qHJW1w2kk/I6cGCGIU+3t6o=",
@@ -289,7 +254,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
@@ -305,7 +270,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -320,7 +285,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1667318090,
         "narHash": "sha256-AvxgT+t1BWZs8IfdseHl8+7wvWWm9pvysupMT9wXdH0=",
@@ -336,30 +301,12 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "naersk": "naersk",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "serokell-nix": "serokell-nix"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673284055,
-        "narHash": "sha256-QW8mJh3d6G1hX3kgcgSwNhoSHXci0RlTwKvLrfrH9YE=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "368e0bb32f1178cf162c2ce5f7e10b7ae211eb26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "serokell-nix": {
@@ -369,7 +316,7 @@
         "flake-utils": "flake-utils_2",
         "gitignore-nix": "gitignore-nix",
         "nix": "nix_2",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1671444753,

--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,9 @@
   inputs = {
     flake-compat.flake = false;
     naersk.url = "github:nix-community/naersk";
-    fenix.url = "github:nix-community/fenix";
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix, flake-compat, serokell-nix, fenix, naersk, ... }:
+  outputs = { self, nixpkgs, flake-utils, nix, serokell-nix, naersk, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system}.extend serokell-nix.overlay;
@@ -66,7 +65,7 @@
           inherit update-daemon;
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           #RUST_LOG = "trace";
           inputsFrom = builtins.attrValues self.packages.${system};
           RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";

--- a/src/flake_lock/mod.rs
+++ b/src/flake_lock/mod.rs
@@ -107,7 +107,7 @@ impl Lock {
                 .get(&self.root.clone())?
                 .clone()
                 .inputs
-                .unwrap_or_default()
+                .unwrap_or_default(),
         )
     }
 
@@ -123,10 +123,9 @@ impl Lock {
         let mut diff: IndexMap<String, InputChange> = IndexMap::new();
 
         for (key, input_a) in new.root_deps().ok_or(LockDiffError::MissingRootNode)? {
-            let value_a = new.get_dep(input_a).ok_or_else(|| LockDiffError::MissingNodeError(
-                key.clone(),
-                "root".to_string(),
-            ))?;
+            let value_a = new
+                .get_dep(input_a)
+                .ok_or_else(|| LockDiffError::MissingNodeError(key.clone(), "root".to_string()))?;
 
             match self.get_root_dep(key.clone()) {
                 Some(value_b) => {

--- a/src/git.rs
+++ b/src/git.rs
@@ -190,7 +190,7 @@ pub fn setup_update_branch(
             .get()
             .peel_to_commit()
             .map_err(SetupUpdateBranchError::PeelUpdateBranchCommit)?;
-        let default_branch_commit = b
+        let default_branch_commit = default_branch
             .get()
             .peel_to_commit()
             .map_err(SetupUpdateBranchError::PeelDefaultBranchCommit)?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -161,6 +161,8 @@ pub enum SetupUpdateBranchError {
     FindDefaultBranch(git2::Error),
     #[error("Error peeling to update branch commit: {0}")]
     PeelUpdateBranchCommit(git2::Error),
+    #[error("Error peeling to default branch commit: {0}")]
+    PeelDefaultBranchCommit(git2::Error),
     #[error("There are human commits in the update branch")]
     HumanCommitsInUpdateBranch,
     #[error("Failed to force-checkout update branch: {0}")]
@@ -176,21 +178,33 @@ pub fn setup_update_branch(
         BranchType::Remote,
     );
 
+    let default_branch = repo
+        .find_branch(
+            &format!("origin/{}", &settings.default_branch),
+            BranchType::Remote,
+        )
+        .map_err(SetupUpdateBranchError::FindDefaultBranch)?;
+
     let branch = if let Ok(b) = update_branch {
         let update_branch_commit = b
             .get()
             .peel_to_commit()
             .map_err(SetupUpdateBranchError::PeelUpdateBranchCommit)?;
-        if update_branch_commit.author().email() != Some(&settings.author.email) {
+        let default_branch_commit = b
+            .get()
+            .peel_to_commit()
+            .map_err(SetupUpdateBranchError::PeelDefaultBranchCommit)?;
+        // NB: we need to handle the case of update branch even with default
+        // branch specially, otherwise we can get spurious "human commits"
+        // errors where the update branch doesn't even have commits.
+        if update_branch_commit.id() != default_branch_commit.id()
+            && update_branch_commit.author().email() != Some(&settings.author.email)
+        {
             return Err(SetupUpdateBranchError::HumanCommitsInUpdateBranch);
         }
         b
     } else {
-        repo.find_branch(
-            &format!("origin/{}", &settings.default_branch),
-            BranchType::Remote,
-        )
-        .map_err(SetupUpdateBranchError::FindDefaultBranch)?
+        default_branch
     };
 
     force_checkout_branch(repo, &settings.update_branch, &branch)?;

--- a/src/request/github.rs
+++ b/src/request/github.rs
@@ -24,7 +24,9 @@ impl From<octocrab::Error> for PullRequestError {
         match e {
             octocrab::Error::GitHub { ref source, .. }
                 if source.message == "Repository was archived so is read-only." =>
-                    PullRequestError::ReadOnlyRepo,
+            {
+                PullRequestError::ReadOnlyRepo
+            }
             e => PullRequestError::GithubError(e),
         }
     }

--- a/src/request/gitlab.rs
+++ b/src/request/gitlab.rs
@@ -46,7 +46,9 @@ pub async fn submit_or_update_merge_request(
         .target_branch(&settings.default_branch)
         .source_branch(&settings.update_branch)
         .build()
-        .map_err(|_| MergeRequestError::GitlabEndpointError("building merge request".to_string()))?;
+        .map_err(|_| {
+            MergeRequestError::GitlabEndpointError("building merge request".to_string())
+        })?;
 
     let mut mr_page: Vec<gitlab::types::MergeRequest> = mr_search.query_async(&gitlab).await?;
 
@@ -57,7 +59,9 @@ pub async fn submit_or_update_merge_request(
             .title(settings.title)
             .description(body)
             .build()
-            .map_err(|_| MergeRequestError::GitlabEndpointError("building merge request".to_string()))?;
+            .map_err(|_| {
+                MergeRequestError::GitlabEndpointError("building merge request".to_string())
+            })?;
 
         let mr: gitlab::types::MergeRequest = mr_edit.query_async(&gitlab).await?;
 
@@ -70,7 +74,9 @@ pub async fn submit_or_update_merge_request(
             .title(settings.title)
             .description(body)
             .build()
-            .map_err(|_| MergeRequestError::GitlabEndpointError("creating merge request".to_string()))?;
+            .map_err(|_| {
+                MergeRequestError::GitlabEndpointError("creating merge request".to_string())
+            })?;
 
         let mr: gitlab::types::MergeRequest = mr_create.query_async(&gitlab).await?;
 
@@ -101,7 +107,9 @@ pub async fn submit_issue_or_merge_request_comment(
         .target_branch(&settings.default_branch)
         .source_branch(&settings.update_branch)
         .build()
-        .map_err(|_| MergeRequestError::GitlabEndpointError("building merge request".to_string()))?;
+        .map_err(|_| {
+            MergeRequestError::GitlabEndpointError("building merge request".to_string())
+        })?;
 
     let mut mr_page: Vec<gitlab::types::MergeRequest> = mr_search.query_async(&gitlab).await?;
 
@@ -112,15 +120,17 @@ pub async fn submit_issue_or_merge_request_comment(
             .merge_request(mr.iid.value())
             .body(body)
             .build()
-            .map_err(|_| MergeRequestError::GitlabEndpointError("building merge request note".to_string()))?;
+            .map_err(|_| {
+                MergeRequestError::GitlabEndpointError("building merge request note".to_string())
+            })?;
 
-        let _ : gitlab::types::Note = mr_note_create.query_async(&gitlab).await?;
+        let _: gitlab::types::Note = mr_note_create.query_async(&gitlab).await?;
     } else {
         // let me = crab.current().user().await?.login;
 
-        let me_query = users::CurrentUser::builder()
-            .build()
-            .map_err(|_| MergeRequestError::GitlabEndpointError("building current user".to_string()))?;
+        let me_query = users::CurrentUser::builder().build().map_err(|_| {
+            MergeRequestError::GitlabEndpointError("building current user".to_string())
+        })?;
 
         let me: gitlab::types::User = me_query.query_async(&gitlab).await?;
 
@@ -145,18 +155,22 @@ pub async fn submit_issue_or_merge_request_comment(
                 .issue(issue.iid.value())
                 .body(body)
                 .build()
-                .map_err(|_| MergeRequestError::GitlabEndpointError("creating issue".to_string()))?;
+                .map_err(|_| {
+                    MergeRequestError::GitlabEndpointError("creating issue".to_string())
+                })?;
 
-            let _ : gitlab::types::Note = issue_note_create.query_async(&gitlab).await?;
+            let _: gitlab::types::Note = issue_note_create.query_async(&gitlab).await?;
         } else {
             let issue_create = projects::issues::CreateIssue::builder()
                 .project(project)
                 .title(title)
                 .description(body)
                 .build()
-                .map_err(|_| MergeRequestError::GitlabEndpointError("creating issue".to_string()))?;
+                .map_err(|_| {
+                    MergeRequestError::GitlabEndpointError("creating issue".to_string())
+                })?;
 
-            let _ : gitlab::types::Issue = issue_create.query_async(&gitlab).await?;
+            let _: gitlab::types::Issue = issue_create.query_async(&gitlab).await?;
         }
     }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -47,7 +47,7 @@ pub async fn submit_or_update_request(
                 Err(e @ github::PullRequestError::ReadOnlyRepo) => {
                     warn!("{}", e);
                     Ok(())
-                },
+                }
                 Err(e) => Err(e.into()),
                 Ok(_) => Ok(()),
             }
@@ -57,17 +57,16 @@ pub async fn submit_or_update_request(
             project,
             token_env_var,
             ..
-        } => {
-            gitlab::submit_or_update_merge_request(
-                settings,
-                base_url,
-                project,
-                token_env_var,
-                diff,
-                submit,
-            )
-            .await.map_err(|e| e.into())
-        }
+        } => gitlab::submit_or_update_merge_request(
+            settings,
+            base_url,
+            project,
+            token_env_var,
+            diff,
+            submit,
+        )
+        .await
+        .map_err(|e| e.into()),
         RepoHandle::GitNone { url } => {
             warn!("Not sending a pull request for {}", url);
             Ok(())

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,7 +59,9 @@ impl std::convert::TryInto<UpdateSettings> for UpdateSettingsOptional {
     fn try_into(self) -> Result<UpdateSettings, Self::Error> {
         Ok(UpdateSettings {
             author: unoption(self.author, "author")?,
-            update_branch: self.update_branch.unwrap_or_else(|| "automatic-update".to_string()),
+            update_branch: self
+                .update_branch
+                .unwrap_or_else(|| "automatic-update".to_string()),
             default_branch: self.default_branch.unwrap_or_else(|| "master".to_string()),
             title: self
                 .title

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,8 +67,8 @@ impl std::convert::TryInto<UpdateSettings> for UpdateSettingsOptional {
             extra_body: self.extra_body.unwrap_or_default(),
             // what if negative number in config?
             cooldown: Duration::from_millis(unoption(self.cooldown, "cooldown")?),
-            inputs: self.inputs.unwrap_or_else(|| vec![]),
-            allow_missing_inputs: self.allow_missing_inputs.unwrap_or_else(|| false),
+            inputs: self.inputs.unwrap_or_default(),
+            allow_missing_inputs: self.allow_missing_inputs.unwrap_or(false),
         })
     }
 }


### PR DESCRIPTION
Problem: `setup_update_branch` unconditionally resets HEAD to the
default branch's HEAD before updating flake.lock. Consequently, even if
the new flake.lock is the same as the one currently on the update
branch, it will force-push regardless.

Solution: During `setup_update_branch`, force the update branch to point
to either the remote update branch head, or the default branch if remote
update branch does not exist. Ensure working tree is checked out to the
update branch.

If there are changes to the `flake.lock` compared to the update branch,
soft-reset to the default branch and commit the changes. Otherwise,
don't.

This uses the same force-checkout workflow as `init_repo`, hence the
code is factored out into a separate function. Simpler approaches (like
`checkout_head` etc) didn't work.

Also fix clippy complaints, run rustfmt and clean-up `flake.nix`.

Off-topic: `nix flake check` complains about `system.stateVersion`. Is it safe to ignore?

Disclaimer: I've tested this a bit, and it seems to work. However, the workflow is surprisingly convoluted, so I'm not 100% positive I've caught all the edge cases.

Resolves #25 