### PR TITLE
[Chore] Make it possible to override input instead of updating

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -11,6 +11,16 @@ let
     lib.mapAttrsFlatten
     (owner: lib.mapAttrsFlatten (repo: settings: { inherit type owner repo settings; })))
     cfg.repos));
+  input_override = lib.types.submodule {
+    input = lib.mkOption {
+      type = lib.types.str;
+      description = "Input to override";
+    };
+    override_url = lib.mkOption {
+      type = lib.types.str;
+      description = "Input to override";
+    };
+  };
 in {
   options.services.update-daemon = with lib;
     with types; {
@@ -97,7 +107,7 @@ in {
           default = 100;
         };
         inputs = mkOption {
-          type = listOf str;
+          type = listOf (either str input_override);
           description = "List of input names to be updated, if empty, all inputs will be updated";
           default = [];
           example = [ "haskell-nix" ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,24 +58,22 @@ fn flake_update(
         nix_flake_update.arg("lock");
         for input in settings.inputs.iter() {
             let input_name = match input {
-                UpdateOrOverrideInput::Update(input_name) => input_name,
-                UpdateOrOverrideInput::Override{input, ..} => input,
+                UpdateOrOverrideInput::Update(input_name) => {
+                    nix_flake_update.arg("--update-input");
+                    nix_flake_update.arg(input_name);
+                    input_name
+                },
+                UpdateOrOverrideInput::Override{input, override_url} => {
+                    nix_flake_update.arg("--override-input");
+                    nix_flake_update.arg(input);
+                    nix_flake_update.arg(override_url);
+                    input
+                },
             };
             // Abort flake update if input is missing from the flake.lock root nodes
             // and allow_missing_inputs is not set
             if !settings.allow_missing_inputs && lock.get_root_dep(input_name.clone()).is_none() {
                 return Err(FlakeUpdateError::MissingInput(input_name.clone()));
-            };
-            match input {
-                UpdateOrOverrideInput::Update(input_name) => {
-                    nix_flake_update.arg("--update-input");
-                    nix_flake_update.arg(input_name);
-                },
-                UpdateOrOverrideInput::Override { input, override_url} => {
-                    nix_flake_update.arg("--override-input");
-                    nix_flake_update.arg(input);
-                    nix_flake_update.arg(override_url);
-                },
             };
         }
     };

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,7 +18,7 @@ pub struct UpdateSettings {
     pub title: String,
     pub extra_body: String,
     pub cooldown: Duration,
-    pub inputs: Vec<String>,
+    pub inputs: Vec<UpdateOrOverrideInput>,
     pub allow_missing_inputs: bool,
 }
 
@@ -36,8 +36,15 @@ pub struct UpdateSettingsOptional {
     pub title: Option<String>,
     pub extra_body: Option<String>,
     pub cooldown: Option<u64>,
-    pub inputs: Option<Vec<String>>,
+    pub inputs: Option<Vec<UpdateOrOverrideInput>>,
     pub allow_missing_inputs: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum UpdateOrOverrideInput {
+    Update (String),
+    Override {input: String, override_url: String},
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Problem: We'd like to have an ability to massively apply flake inputs overrides in our repos in order to test some updates before merging potentially breaking changes.

Solution: Make it possible to specify an attrset of input name and override url in the list of inputs to update. For each such entry in the inputs list, 'flake.lock' update will be done using '--override-input' instead of '--update-input'.

Config usage example for the overriding:
```
...
    "inputs": [
        {
            "input": "nixpkgs",
            "override_url": "github:nixos/nixpkgs"
        }
    ],
    "repos": [
      {
        "owner": "serokell",
        "repo": "update-daemon",
        "settings": {},
        "type": "github"
      }
    ],
...
```

Related YT issue: https://issues.serokell.io/issue/OPS-1478