### PR TITLE
[#33] Support commit signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +236,22 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cstr-argument"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
+dependencies = [
+ "cfg-if",
+ "memchr",
+]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "cxx"
@@ -553,6 +578,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpg-error"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7073b9ac823434ae73608715086e944d694a7ce2677371b8c5253300d1f767f1"
+dependencies = [
+ "libgpg-error-sys",
+]
+
+[[package]]
+name = "gpgme"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64070c0f3dc514656d6d21b5c0b8a088db2f74d889410378340039088d6ae32b"
+dependencies = [
+ "bitflags",
+ "conv",
+ "cstr-argument",
+ "gpg-error",
+ "gpgme-sys",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "static_assertions",
+]
+
+[[package]]
+name = "gpgme-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9555986d7ef4c6c5bb57469f74df57bcc1a7c686a6de7c9be71e3377a095756"
+dependencies = [
+ "libc",
+ "libgpg-error-sys",
+ "winreg 0.9.0",
+]
+
+[[package]]
 name = "graphql-introspection-query"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,12 +751,6 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
@@ -722,7 +778,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate 1.0.2",
+ "httpdate",
  "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
@@ -767,7 +823,7 @@ dependencies = [
  "base64 0.13.0",
  "bytes",
  "http",
- "httpdate 0.3.2",
+ "httpdate",
  "language-tags",
  "mime",
  "percent-encoding",
@@ -915,6 +971,16 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libgpg-error-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1aedf0efc5d25fdd08eb52b0759c71d02ac77fd1879b96e95211239528897"
+dependencies = [
+ "libc",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -1412,7 +1478,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -1650,6 +1716,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1939,6 +2011,7 @@ dependencies = [
  "futures",
  "git2",
  "gitlab",
+ "gpgme",
  "indexmap",
  "log",
  "merge",
@@ -2191,6 +2264,24 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ futures = "0.3"
 chrono = "0.4"
 indexmap = { version = "1.6", features = [ "serde", "serde-1" ] }
 merge = "0.1"
+gpgme = "0.10.0"

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
           buildInputs = [
             pkgs.openssl_1_1
             pkgs.libgit2
+            pkgs.libgpg-error
+            pkgs.gpgme
           ];
 
           postInstall =

--- a/module.nix
+++ b/module.nix
@@ -107,6 +107,16 @@ in {
           description = "If set to true, the update-daemon will not abort flake update if one of the names specified in the inputs option is not present in the flake.lock root node";
           default = false;
         };
+        sign_commits = mkOption {
+          type = bool;
+          description = "Whether to sign commits, the signing key must be available in gpg-agent under the root user";
+          default = false;
+        };
+        signing_key = mkOption {
+          type = nullOr str;
+          description = "Signing key ID or fingerprint, if not set, the default key will be used";
+          default = null;
+        };
       };
     };
   config = lib.mkIf cfg.enable {

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,6 +20,8 @@ pub struct UpdateSettings {
     pub cooldown: Duration,
     pub inputs: Vec<String>,
     pub allow_missing_inputs: bool,
+    pub sign_commits: bool,
+    pub signing_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -38,6 +40,8 @@ pub struct UpdateSettingsOptional {
     pub cooldown: Option<u64>,
     pub inputs: Option<Vec<String>>,
     pub allow_missing_inputs: Option<bool>,
+    pub sign_commits: Option<bool>,
+    pub signing_key: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -71,6 +75,8 @@ impl std::convert::TryInto<UpdateSettings> for UpdateSettingsOptional {
             cooldown: Duration::from_millis(unoption(self.cooldown, "cooldown")?),
             inputs: self.inputs.unwrap_or_default(),
             allow_missing_inputs: self.allow_missing_inputs.unwrap_or(false),
+            sign_commits: self.sign_commits.unwrap_or(false),
+            signing_key: self.signing_key,
         })
     }
 }


### PR DESCRIPTION
Problem: Repositories within our organization tend to enforce commit signing via GPG. However, update-daemon doesn't do any signing. As a result, it's not always possible to merge update PRs as is.

Solution: Add the ability to sign commits with GPG key.

Fixes #33 