### PR TITLE
[Chore] Run service as regular user

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -128,11 +128,20 @@ in {
       };
     };
   config = lib.mkIf cfg.enable {
+    users.users.update-daemon = {
+      isSystemUser = true;
+      home = "/var/lib/update-daemon";
+      createHome = true;
+      group = "update-daemon";
+    };
+    users.groups.update-daemon = {};
+
     systemd.services.update-daemon = {
       description = "A daemon to update nix flakes";
       serviceConfig = {
         Type = "oneshot";
         EnvironmentFile = cfg.secretFile;
+        User = "update-daemon";
       };
       path = [ cfg.package ];
       script = ''


### PR DESCRIPTION
Problem: The systemd service is currently run by root, and the current version of libgit2 can no longer load the known_hosts due to the $HOME env variable not being set. Moreover, there is no reason to run the update-daemon as root.

Solution: Run update-daemon as regular user.