### PR TITLE
[#32] Fix rate limit abuse errors

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -146,6 +146,14 @@ in {
       path = [ cfg.package ];
       script = ''
         ${cfg.agentSetup}
+
+        # Provide GITHUB_TOKEN to nix to avoid API rate limits
+        if [[ $GITHUB_TOKEN ]]; then
+          export NIX_CONFIG="extra-access-tokens = github.com=$GITHUB_TOKEN"
+        else
+          echo "GITHUB_TOKEN is not set, you may encounter GitHub API rate limits"
+        fi
+
         update-daemon ${
           builtins.toFile "config.json"
           (builtins.toJSON (cfg.settings // { repos = repos ++ cfg.extraRepos; }))


### PR DESCRIPTION
Problem: update-daemon is getting rate-limit abuse errors.

Solution: Add the github token to the extra-acess-tokens of the nix configuration.

closes #32 