### PR TITLE
[Chore] Run CI on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name: nix flake check
-on: push
+on:
+  pull_request:
+  push:
+    branches: master
 
 jobs:
   check:


### PR DESCRIPTION
Problem: Currently, GA pipeline is only triggered by pushes to branches within the repo. As a result, CI is never triggered for PRs from forks.

Solution: Run CI on pull requests and pushes to 'master' branch.