### PR TITLE
[OPS-1548] Update nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
   inputs = {
     flake-compat.flake = false;
     naersk.url = "github:nix-community/naersk";
-    nix.url = "github:nixos/nix?ref=2.21.4";
+    nix.url = "github:nixos/nix?ref=2.32.4";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Problem: The current nix version is quite old and does not work with flake registry created by newer nix versions.

Solution: Update nix to version 2.32.4.